### PR TITLE
register.html -sivun linkki kirjautumissivulle korjattu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![GitHub Actions](https://github.com/HJJHeinonen/OHTU-lukuvinkkikirjasto/workflows/CI/badge.svg) [![codecov](https://codecov.io/gh/HJJHeinonen/OHTU-lukuvinkkikirjasto/branch/master/graph/badge.svg?token=S3WQ2AE38H)](https://codecov.io/gh/HJJHeinonen/OHTU-lukuvinkkikirjasto)
 
-Tämä repositorio on Helsingin yliopiston Ohjelmistotuotanto-kurssin miniprojektia varten. 
+Tämä repositorio on Helsingin yliopiston Ohjelmistotuotanto-kurssin miniprojektia varten.
 
-### Lukuvinkkisovellus 
+### Lukuvinkkisovellus
 
 Sovelluksen tarkoitus on pystyä tallettamaan erinäisiä lukuvinkkejä, sekä selaamaan niitä.
 
@@ -86,6 +86,3 @@ robot src/tests/robotframework
 ```
 
 **Mikäli testien ajaminen ei onnistu, tarkistathan, että suhteellinen polku hakemistoon on oikea**.
-
-
-

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -26,7 +26,7 @@
     <input type="submit" value="Rekisteröidy" class="button">
 </form>
 <br>
-Onko sinulla jo käyttäjätunnus olemassa? Tästä pääset <a href="/login" class="button">kirjautumaan sisään</a>!
+Onko sinulla jo käyttäjätunnus olemassa? Tästä pääset <a href="/" class="button">kirjautumaan sisään</a>!
 <br>
 
 <script>


### PR DESCRIPTION
Register.html sivulla oli linkki resurssiin "/login". Kyseinen route ei ole kuitenkaan määritelty ja oikea route on "/", eli palvelun juurisivu.